### PR TITLE
Implementación del CRUD de Tipo Acto Litúrgico

### DIFF
--- a/liturgia-backend/src/main/java/com/example/demo/controller/TipoActoLiturgicoController.java
+++ b/liturgia-backend/src/main/java/com/example/demo/controller/TipoActoLiturgicoController.java
@@ -1,0 +1,63 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.TipoActoLiturgico;
+import com.example.demo.service.TipoActoLiturgicoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/tipos-actos")
+public class TipoActoLiturgicoController {
+    
+    @Autowired
+    private TipoActoLiturgicoService tipoActoLiturgicoService;
+
+    @GetMapping
+    public List<TipoActoLiturgico> getAllTipos(){
+        return tipoActoLiturgicoService.getAllTipos();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<TipoActoLiturgico> getTipoById(@PathVariable Long id) {
+        TipoActoLiturgico tipoActoLiturgico = tipoActoLiturgicoService.getTipoById(id);
+        if (tipoActoLiturgico == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(tipoActoLiturgico);
+    }
+    
+    @PostMapping
+    public ResponseEntity<TipoActoLiturgico> createTipoActoLiturgico(@RequestBody TipoActoLiturgico tipoActoLiturgico) {
+        if (tipoActoLiturgico.getDescripcion() == null || tipoActoLiturgico.getDescripcion().isEmpty()) {
+            return ResponseEntity.badRequest().build();
+        }
+        TipoActoLiturgico nuevoTipo = tipoActoLiturgicoService.saveTipoActoLiturgico(tipoActoLiturgico);
+        return ResponseEntity.ok(nuevoTipo);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<TipoActoLiturgico> updateTipoActoLiturgico(@PathVariable Long id, @RequestBody TipoActoLiturgico tipoActoLiturgico) {
+        TipoActoLiturgico tipoExistente = tipoActoLiturgicoService.getTipoById(id);
+        if (tipoExistente == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        tipoActoLiturgico.setId(id);
+        TipoActoLiturgico actualizado = tipoActoLiturgicoService.updateTipoActoLiturgico(id, tipoActoLiturgico);
+        return ResponseEntity.ok(actualizado);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTipoActoLiturgico(@PathVariable Long id) {
+        TipoActoLiturgico tipoActoLiturgico = tipoActoLiturgicoService.getTipoById(id);
+        if (tipoActoLiturgico == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        tipoActoLiturgicoService.deleteTipoActoLiturgico(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/liturgia-backend/src/main/java/com/example/demo/model/TipoActoLiturgico.java
+++ b/liturgia-backend/src/main/java/com/example/demo/model/TipoActoLiturgico.java
@@ -1,0 +1,45 @@
+package com.example.demo.model;
+
+import jakarta.persistence.*;
+
+@Entity
+public class TipoActoLiturgico {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    private String nombre;
+    private String descripcion;
+
+    public TipoActoLiturgico() {}
+    
+    public TipoActoLiturgico(String nombre){
+        this.nombre = nombre;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+    
+}

--- a/liturgia-backend/src/main/java/com/example/demo/repository/TipoActoLiturgicoRepository.java
+++ b/liturgia-backend/src/main/java/com/example/demo/repository/TipoActoLiturgicoRepository.java
@@ -1,0 +1,8 @@
+package com.example.demo.repository;
+
+import com.example.demo.model.TipoActoLiturgico;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TipoActoLiturgicoRepository extends JpaRepository<TipoActoLiturgico, Long>{    
+
+}

--- a/liturgia-backend/src/main/java/com/example/demo/service/TipoActoLiturgicoService.java
+++ b/liturgia-backend/src/main/java/com/example/demo/service/TipoActoLiturgicoService.java
@@ -1,0 +1,40 @@
+package com.example.demo.service;
+
+
+import com.example.demo.model.TipoActoLiturgico;
+import com.example.demo.repository.TipoActoLiturgicoRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class TipoActoLiturgicoService {
+    
+    @Autowired
+    private TipoActoLiturgicoRepository tipoActoLiturgicoRepository;
+
+    public List<TipoActoLiturgico> getAllTipos(){
+        return tipoActoLiturgicoRepository.findAll();
+    }
+
+    public TipoActoLiturgico getTipoById(Long id){
+        return tipoActoLiturgicoRepository.findById(id).orElse(null);
+    }
+
+    public TipoActoLiturgico saveTipoActoLiturgico(TipoActoLiturgico tipoActoLiturgico){
+        return tipoActoLiturgicoRepository.save(tipoActoLiturgico);
+    }
+
+    public void deleteTipoActoLiturgico(Long id){
+        tipoActoLiturgicoRepository.deleteById(id);
+    }
+
+    public TipoActoLiturgico updateTipoActoLiturgico(Long id,TipoActoLiturgico tipoActoLiturgico){
+        if(tipoActoLiturgicoRepository.existsById(id)){
+            tipoActoLiturgico.setId(id);
+            return tipoActoLiturgicoRepository.save(tipoActoLiturgico);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Este PR incluye la implementación del CRUD completo para gestionar los tipos de actos litúrgicos, permitiendo crear, leer, actualizar y eliminar tipos de actos.